### PR TITLE
feat(security): Remove Person from Security Group + Disable Person

### DIFF
--- a/Net.Pokeshot.JiveSdk/Clients/PeopleClient.cs
+++ b/Net.Pokeshot.JiveSdk/Clients/PeopleClient.cs
@@ -385,6 +385,7 @@ namespace Net.Pokeshot.JiveSdk.Clients
             });
 
             json = json.Replace($"\"id\": {person.id}", $"\"id\" : \"{person.id}\"");
+            json = json.Replace($"\"_disabled\": true", $"\"enabled\" : false");
 
             string result;
             try

--- a/Net.Pokeshot.JiveSdk/Clients/SecurityGroupsClient.cs
+++ b/Net.Pokeshot.JiveSdk/Clients/SecurityGroupsClient.cs
@@ -115,5 +115,19 @@ namespace Net.Pokeshot.JiveSdk.Clients
                 }
             }
         }
+
+
+        /// <summary>
+        /// Add the specified people as regular members of the specified security group.
+        /// </summary>
+        /// <param name="securityGroupID">ID of the security group to which regular members should be added</param>
+        /// <param name="personID">ID of the person for which to select memberships</param>
+        /// <returns>Category object representing the newly created category</returns>
+        public void RemoveMember(int securityGroupID, int personID)
+        {
+            //construct the url for the HTTP request based on the user specifications
+            string url = securityGroupsUrl + "/" + securityGroupID.ToString() + "/members/" + personID.ToString();
+            DeleteAbsolute(url);
+        }
     }
 }

--- a/Net.Pokeshot.JiveSdk/Models/Person.cs
+++ b/Net.Pokeshot.JiveSdk/Models/Person.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -30,8 +31,10 @@ namespace Net.Pokeshot.JiveSdk.Models
 
     }
 
+    [DataContract]
     public class JivePerson
     {
+        [DataMember(IsRequired = false)]
         public bool enabled { get; set; }
         public bool external { get; set; }
         public bool externalContributor { get; set; }

--- a/Net.Pokeshot.JiveSdk/Models/Person.cs
+++ b/Net.Pokeshot.JiveSdk/Models/Person.cs
@@ -31,11 +31,10 @@ namespace Net.Pokeshot.JiveSdk.Models
 
     }
 
-    [DataContract]
     public class JivePerson
     {
-        [DataMember(IsRequired = false)]
         public bool enabled { get; set; }
+        public bool _disabled { get; set; } // not actual api property, used for disable action
         public bool external { get; set; }
         public bool externalContributor { get; set; }
         public List<ExternalIdentity> externalIdentities { get; set; }


### PR DESCRIPTION
Adds `SecurityGroupsClient.RemoveMember(int securityGroupID, int personID)` to remove a person from a security group

Also, allows a person to be disabled by setting a disabled flag and updating the JivePerson.
It uses a hack by setting a new `_disabled` flag to true
The json seralization ignores default values; so, enabled = false gets dropped as property and not sent through to the api